### PR TITLE
Pass in extensions from Jest config to our resolver

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ try {
 }
 
 if (pnp) {
-  module.exports = (request, {basedir}) => {
-    const resolution = pnp.resolveRequest(request, `${basedir}/`);
+  module.exports = (request, {basedir, extensions}) => {
+    const resolution = pnp.resolveRequest(request, `${basedir}/`, {extensions});
 
     // When the request is a native module, Jest expects to get the string back unmodified, but pnp returns null instead.
     if (resolution === null) {


### PR DESCRIPTION
Without this I wasn't able to get Jest to see my `.jsx` files.
