### PR TITLE
Make defaultResolver type more flexible

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,10 @@
-type JestResolverOptions = {
+type JestResolverOptions<T> = {
   basedir: string;
-  defaultResolver: (request: string, opts: any) => string,
+  defaultResolver: T;
   extensions?: Array<string>,
 };
 
-export default function resolve(
-  request: string,
-  options: JestResolverOptions,
-): string;
+export default function resolve<D extends (request: string, options: JestResolverOptions<D>) => any>(
+  request: string, 
+  options: JestResolverOptions<D>
+): ReturnType<D>


### PR DESCRIPTION
There is [work](https://github.com/facebook/jest/pull/11540) ongoing in jest to allow async resolvers, and since jest-pnp-resolver is built-in, we'll need a small tweak to the typescript types.  This PR just makes the types a bit more flexible, to allow an async `defaultResolver` while continuing to also support sync as well.  

The trick here is using the `ReturnType` of the default resolver as the return type of the pnp resolver.