### PR TITLE
feat(ts): allow `readonly` arrays

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 type JestResolverOptions = {
   basedir: string;
   defaultResolver: (request: string, opts: any) => string,
-  extensions?: Array<string>,
+  extensions?: ReadonlyArray<string>,
 };
 
 export default function resolve(


### PR DESCRIPTION
Consumers can still pass mutable ones as they extend with mutable functions, but this allows be to also pass readonly ones